### PR TITLE
Remove exception when securevault is null

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigProviderFactory.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigProviderFactory.java
@@ -67,8 +67,7 @@ public class ConfigProviderFactory {
         }
         //check whether securevault is null. proceed if not null.
         if (secureVault == null) {
-            throw new ConfigurationException("No securevault service found. configuration provider will not be " +
-                    "initialized!");
+            logger.debug("No securevault service found. configuration provider will not be initialized!");
         }
         if (logger.isDebugEnabled()) {
             logger.debug("initialize config provider instance from configuration file: " + filePath.toString());

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderFactoryTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderFactoryTest.java
@@ -81,11 +81,11 @@ public class ConfigProviderFactoryTest {
                 secureVault);
     }
 
-    @Test(description = "test case when securevault is not provided, when getting config provider", expectedExceptions
-            = ConfigurationException.class, expectedExceptionsMessageRegExp = "No securevault service found. " +
-            "configuration provider will not be initialized!")
+    @Test(description = "test case when securevault is not provided, when getting config provider")
     public void secureVaultNotProvidedTestCase() throws ConfigurationException {
-        ConfigProviderFactory.getConfigProvider(TestUtils.getResourcePath("conf", "Example.yaml").get(), null);
+        Assert.assertNotNull(
+                ConfigProviderFactory.getConfigProvider(TestUtils.getResourcePath("conf", "Example.yaml").get(), null),
+                "Couldn't initialize ConfigProvider without Secvault");
     }
 
     @Test(description = "test case for xml configuration file", expectedExceptions = ConfigurationException.class)


### PR DESCRIPTION
This removes exception which gets thrown when the securevault is null. Users who want to use carbon-config without securevault now can use the getConfigProvider method passing null for securevault.

Resolves #40 