### PR TITLE
Add new maven goal to collect config docs when creating distribution

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigConstants.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigConstants.java
@@ -23,6 +23,7 @@ package org.wso2.carbon.config;
 public final class ConfigConstants {
 
     public static final String NULL = "NULL";
+    public static final String NOT_APPLICABLE = "na";
     public static final String TEMP_CONFIG_FILE_NAME = "temp_config_classnames.txt";
     public static final String CONFIG_DIR = "config-docs";
     public static final String DEPLOYMENT_CONFIG_YAML = "deployment.yaml";

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/annotation/Configuration.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/annotation/Configuration.java
@@ -36,6 +36,9 @@ public @interface Configuration {
     // needed only for root configuration bean
     String namespace() default ConfigConstants.NULL;
 
+    //need only for the root configuration bean. This will be the menu item from the configuration docs
+    String displayName() default ConfigConstants.NULL;
+
     // field description, required
     String description();
 }

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/annotation/Element.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/annotation/Element.java
@@ -15,6 +15,8 @@
  */
 package org.wso2.carbon.config.annotation;
 
+import org.wso2.carbon.config.ConfigConstants;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,4 +36,7 @@ public @interface Element {
     String description();
 
     boolean required() default false;
+
+    //This is applied only for option fields. Define possible values in
+    String[] possibleValues() default ConfigConstants.NOT_APPLICABLE;
 }

--- a/extensions/org.wso2.carbon.config.maven.plugin/src/main/java/org/wso2/carbon/config/maven/plugin/ConfigDocumentMojo.java
+++ b/extensions/org.wso2.carbon.config.maven.plugin/src/main/java/org/wso2/carbon/config/maven/plugin/ConfigDocumentMojo.java
@@ -189,7 +189,7 @@ public class ConfigDocumentMojo extends AbstractMojo {
             throw new MojoExecutionException("Error while creating new resource file from the classpath", e);
         }
 
-        // add configguration document to the project resources under config-docs/ directory.
+        // add configuration document to the project resources under config-docs/ directory.
         Resource resource = new Resource();
         resource.setDirectory(configDir.getAbsolutePath());
         resource.setTargetPath(ConfigConstants.CONFIG_DIR);

--- a/extensions/org.wso2.carbon.config.maven.plugin/src/main/java/org/wso2/carbon/config/maven/plugin/ProductConfigurationMojo.java
+++ b/extensions/org.wso2.carbon.config.maven.plugin/src/main/java/org/wso2/carbon/config/maven/plugin/ProductConfigurationMojo.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.config.maven.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * This class will create zip archive combining all configuration documents coming with features.
+ * This is applied when creating product distribution. plugin will collect config-docs from the features in p2-repo
+ * and generate zip archive.
+ *
+ * @since 2.0.6
+ */
+@Mojo(name = "collect-docs")
+public class ProductConfigurationMojo extends AbstractMojo {
+    private static final Logger logger = LoggerFactory.getLogger(ProductConfigurationMojo.class.getName());
+    private static final String P2_REPO_DIR = "p2-repo";
+    private static final String FEATURES_DIR = "features";
+    private static final String CONFIG_DOCS_DIR = "config-docs/";
+
+    @Parameter(defaultValue = "${project}", required = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        File outputDirectory = new File(project.getBuild().getOutputDirectory());
+        Path featurePath = Paths.get(outputDirectory.getParent(), P2_REPO_DIR, FEATURES_DIR);
+        File[] featuresList = featurePath.toFile().listFiles();
+        if (featuresList == null) {
+            return;
+        }
+
+        InputStream inputStream = null;
+        FileOutputStream outputStream = null;
+        for (File file : featuresList) {
+            try (JarFile jar = new JarFile(file)) {
+                JarEntry configDocs = jar.getJarEntry(CONFIG_DOCS_DIR);
+                if (configDocs != null) {
+                    Enumeration enumEntries = jar.entries();
+                    while (enumEntries.hasMoreElements()) {
+                        JarEntry jarEntry = (JarEntry) enumEntries.nextElement();
+                        if (!jarEntry.getName().startsWith("config-docs/")) {
+                            continue;
+                        }
+                        File destFile = new File(outputDirectory.getParent() , jarEntry.getName());
+                        if (jarEntry.isDirectory()) {
+                            if (!destFile.exists() && !destFile.mkdirs()) {
+                                throw new MojoExecutionException("Error while creating config directory in classpath");
+                            }
+                            continue;
+                        }
+                        inputStream = jar.getInputStream(jarEntry);
+                        outputStream = new FileOutputStream(destFile);
+                        while (inputStream.available() > 0) {
+                            outputStream.write(inputStream.read());
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error while opening feature jarfile", e);
+            } finally {
+                try {
+                    if (outputStream != null) {
+                        outputStream.close();
+                    }
+                    if (inputStream != null) {
+                        inputStream.close();
+                    }
+                } catch (IOException e) {
+                    logger.error("Error while closing the input stream", e);
+                }
+
+            }
+        }
+    }
+}

--- a/samples/config-generator/src/main/java/org/wso2/carbon/config/samples/ParentConfiguration.java
+++ b/samples/config-generator/src/main/java/org/wso2/carbon/config/samples/ParentConfiguration.java
@@ -28,10 +28,11 @@ import java.util.Locale;
  *
  * @since 1.0.0
  */
-@Configuration(namespace = "wso2.configuration", description = "Parent configuration")
+@Configuration(namespace = "wso2.configuration", displayName = "Parent Configurations" , description = "Parent " +
+        "configuration")
 public class ParentConfiguration {
 
-    @Element(description = "An example element for this configuration")
+    @Element(description = "An example element for this configuration", possibleValues = {"WSO2", "MV"})
     private String name = "WSO2";
 
     @Element(description = "Another example element in the config", required = true)


### PR DESCRIPTION
With this change, in order to collect config-docs from product distribution, we need to add below plugin configuration to distribution pom.xml after carbon-feature-plugin.

````xml
            <plugin>
                <groupId>org.wso2.carbon.config</groupId>
                <artifactId>org.wso2.carbon.config.maven.plugin</artifactId>
                <version>2.0.6-SNAPSHOT</version>
                <executions>
                    <execution>
                        <phase>package</phase>
                        <goals>
                            <goal>collect-docs</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
````