### PR TITLE
Fix server startup error in windows

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
@@ -38,6 +38,8 @@ public class ConfigurationUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationUtils.class);
     private static final Pattern varPattern = Pattern.compile("\\$\\{([^}]*)}");
+    private static final char[] specialCharArray = new char[]{'\\', '+', '-', '!', '(', ')', ':', '^', '[', ']',
+            '\"', '{', '}', '~', '*', '?', '|', '&', ';', '/'};
 
     private ConfigurationUtils() {
     }
@@ -162,6 +164,7 @@ public class ConfigurationUtils {
 
     /**
      * Returns replace value with escaped characters.
+     *
      * @param value replaced values
      * @return value with escaped characters
      */
@@ -172,10 +175,14 @@ public class ConfigurationUtils {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
-            if (c == '\\' || c == '+' || c == '-' || c == '!'  || c == '(' || c == ')' || c == ':'
-                    || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
-                    || c == '*' || c == '?' || c == '|' || c == '&'  || c == ';' || c == '/'
-                    || Character.isWhitespace(c)) {
+
+            boolean charExists = false;
+            for (char s : specialCharArray) {
+                if (c == s) {
+                    charExists = true;
+                }
+            }
+            if (charExists || Character.isWhitespace(c)) {
                 sb.append('\\');
             }
             sb.append(c);

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
@@ -159,4 +159,24 @@ public class ConfigurationUtils {
         }
         return value;
     }
+
+    /**
+     * Returns replace value with escaped characters.
+     * @param value replaced values
+     * @return value with escaped characters
+     */
+    public static String escapeSpecialCharacters(String value) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\\' || c == '+' || c == '-' || c == '!'  || c == '(' || c == ')' || c == ':'
+                    || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
+                    || c == '*' || c == '?' || c == '|' || c == '&'  || c == ';' || c == '/'
+                    || Character.isWhitespace(c)) {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
@@ -166,6 +166,9 @@ public class ConfigurationUtils {
      * @return value with escaped characters
      */
     public static String escapeSpecialCharacters(String value) {
+        if (value == null) {
+            return null;
+        }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProviderImpl.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProviderImpl.java
@@ -674,12 +674,14 @@ public class ConfigProviderImpl implements ConfigProvider {
         String newValue = func.apply(key);
         //If the new value is not null, replace the placeholder with the new value and return the string.
         if (newValue != null) {
-            return inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" + newValue + "$8");
+            return inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" +
+                    ConfigurationUtils.escapeSpecialCharacters(newValue) + "$8");
         }
         //If the new value is empty and the default value is not empty, replace the placeholder with the default
         // value and return the string
         if (defaultValue != null) {
-            return inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" + defaultValue + "$8");
+            return inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" +
+                    ConfigurationUtils.escapeSpecialCharacters(defaultValue) + "$8");
         }
         //Otherwise print an error message and throw na exception
         String msg;

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProviderImpl.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProviderImpl.java
@@ -645,7 +645,8 @@ public class ConfigProviderImpl implements ConfigProvider {
                         SecureVault secureVault = getSecureVault().orElseThrow(() ->
                                 new ConfigurationRuntimeException("Secure Vault service is not available"));
                         String newValue = new String(secureVault.resolve(value));
-                        inputString = inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" + newValue + "$8");
+                        inputString = inputString.replaceFirst(PLACEHOLDER_REGEX, "$1" + ConfigurationUtils
+                                .escapeSpecialCharacters(newValue) + "$8");
                     } catch (SecureVaultException e) {
                         throw new ConfigurationRuntimeException("Unable to resolve the given alias", e);
                     }

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.config;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.utils.EnvironmentUtils;
 
 /**
@@ -111,5 +112,13 @@ public class UtilsTest {
         String config = "${" + UTIL_ENV + "}" + pathSeparator + "deployment" + pathSeparator;
         Assert.assertEquals(ConfigurationUtils.substituteVariables(config),
                 path + pathSeparator + "deployment" + pathSeparator);
+    }
+
+    @Test
+    public void testEscapeSpecialCharacters() {
+        String inputString = "C:\\Software\\WSO2*Kernal-5.0.0\\wso2\\worker\\bin";
+        String expectedString = "C\\:\\\\Software\\\\WSO2\\*Kernal\\-5.0.0\\\\wso2\\\\worker\\\\bin";
+        String outputString = ConfigurationUtils.escapeSpecialCharacters(inputString);
+        Assert.assertEquals(expectedString, outputString);
     }
 }

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
@@ -120,4 +120,11 @@ public class UtilsTest {
         String outputString = ConfigurationUtils.escapeSpecialCharacters(inputString);
         Assert.assertEquals(expectedString, outputString);
     }
+
+    @Test
+    public void testEscapeSpecialCharactersWithNullValue() {
+        String inputString = null;
+        String outputString = ConfigurationUtils.escapeSpecialCharacters(inputString);
+        Assert.assertNull(outputString);
+    }
 }

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
@@ -18,7 +18,6 @@ package org.wso2.carbon.config;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.utils.EnvironmentUtils;
 
 /**

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/UtilsTest.java
@@ -113,18 +113,16 @@ public class UtilsTest {
                 path + pathSeparator + "deployment" + pathSeparator);
     }
 
-    @Test
-    public void testEscapeSpecialCharacters() {
-        String inputString = "C:\\Software\\WSO2*Kernal-5.0.0\\wso2\\worker\\bin";
-        String expectedString = "C\\:\\\\Software\\\\WSO2\\*Kernal\\-5.0.0\\\\wso2\\\\worker\\\\bin";
-        String outputString = ConfigurationUtils.escapeSpecialCharacters(inputString);
-        Assert.assertEquals(expectedString, outputString);
+    @DataProvider(name = "params")
+    public Object[][] createParamValues() {
+        return new Object[][]{{"C:\\Software\\WSO2*Kernal-5.0.0\\wso2\\worker\\bin",
+                "C\\:\\\\Software\\\\WSO2\\*Kernal\\-5.0.0\\\\wso2\\\\worker\\\\bin"},
+                {null, null}};
     }
 
-    @Test
-    public void testEscapeSpecialCharactersWithNullValue() {
-        String inputString = null;
+    @Test(dataProvider = "params")
+    public void testEscapeSpecialCharacters(String inputString, String expectedString) {
         String outputString = ConfigurationUtils.escapeSpecialCharacters(inputString);
-        Assert.assertNull(outputString);
+        Assert.assertEquals(expectedString, outputString);
     }
 }

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestUtils.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestUtils.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.config.configprovider;
 
-import org.wso2.carbon.secvault.SecureVaultUtils;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -40,7 +39,7 @@ public class TestUtils {
      * @return path of the resources
      */
     public static Optional<Path> getResourcePath(String... resourcePaths) {
-        URL resourceURL = SecureVaultUtils.class.getClassLoader().getResource("");
+        URL resourceURL = TestUtils.class.getClassLoader().getResource("");
         if (resourceURL != null) {
             String resourcePath = resourceURL.getPath();
             if (resourcePath != null) {


### PR DESCRIPTION
## Purpose
Resolves #61 

## Goals
Fix server startup error in windows environment

## Approach
We use String replaceFirst method to replace key(sys:,env:,sec:) with values. if the value has special characters like '\', it treats as special character and skip them when replacing. So we need to add escape character before calling String replaceFirst method 

## User stories
Server cannot start in windows environment

## Automation tests
 - Unit tests 
   unit test added to the new Utils method

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Windows