### PR TITLE
 Update ConfigReader to support merging both file and string as the content

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/ConfigFileReader.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/ConfigFileReader.java
@@ -91,7 +91,7 @@ public abstract class ConfigFileReader {
                return ymlMerger.mergeToString(configContentList);
             } catch (IOException e) {
                 String message = "Error occurred while overriding the default deployment configuration with provided" +
-                        "custom configuration file";
+                        "custom configurations.";
                 log.error(message);
                 throw new ConfigurationException(message, e);
             }

--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/YmlMerger.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/YmlMerger.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 /**
- *
+ * Merge multiple YML files into a single file, and substitute for any environment variables found.
  */
 public class YmlMerger {
 


### PR DESCRIPTION
## Purpose
> Allow the user to provide custom deployment configuration passed as a file or a string. This will merge with existing deployment.yaml

## Approach
> User can pass as similar to below.
./carbon.sh -Dconfig="wso2.carbon:
  id: wso2-sp"