### PR TITLE
Add support for root level lists under namespace

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/ConfigurationUtils.java
@@ -17,7 +17,9 @@ package org.wso2.carbon.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,7 +61,15 @@ public class ConfigurationUtils {
 
         map.entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
-                .forEach(entry -> deploymentConfigs.put(entry.getKey(), yaml.dumpAsMap(entry.getValue())));
+                .forEach((entry) -> {
+                    String yamlValue;
+                    if (entry.getValue() instanceof Map) {
+                        yamlValue = yaml.dumpAsMap(entry.getValue());
+                    } else {
+                        yamlValue = yaml.dumpAs(entry.getValue(), Tag.SEQ, DumperOptions.FlowStyle.BLOCK);
+                    }
+                    deploymentConfigs.put(entry.getKey(), yamlValue);
+                });
         return deploymentConfigs;
     }
 

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderImplTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderImplTest.java
@@ -788,6 +788,39 @@ public class ConfigProviderImplTest {
         EnvironmentUtils.unsetEnvironmentVariables(envVariable);
     }
 
+    @Test(description = "This test will test functionality of namespace root level list objects")
+    public void configObjectWithConstructorTestCase() throws ConfigurationException {
+        ConfigFileReader fileReader = new YAMLBasedConfigFileReader(TestUtils.getResourcePath("conf",
+                "Example2.yaml").get());
+        ConfigProvider configProvider = new ConfigProviderImpl(fileReader, secureVault);
+
+        ArrayList<HashMap> testTransports =
+                                        ((ArrayList<HashMap>) configProvider.getConfigurationObject("testTransports2"));
+
+        Assert.assertEquals(testTransports.size(), 3);
+
+        HashMap<String, Object> testTransport1 = ((HashMap<String, Object>) testTransports.get(0).get("testTransport"));
+        Assert.assertEquals(testTransport1.get("name"), "abc");
+        Assert.assertEquals(testTransport1.get("port"), 9090);
+        Assert.assertEquals(testTransport1.get("secure"), true);
+        Assert.assertEquals(testTransport1.get("desc"), "This transport will use 8000 as its port");
+        Assert.assertEquals(testTransport1.get("password"), PASSWORD);
+
+        //Transport 2
+        HashMap<String, Object> testTransport2 = ((HashMap<String, Object>) testTransports.get(1).get("testTransport"));
+        Assert.assertEquals(testTransport2.get("name"), "pqrs");
+        Assert.assertEquals(testTransport2.get("port"), 8501);
+        Assert.assertEquals(testTransport2.get("secure"), true);
+        Assert.assertEquals(testTransport2.get("desc"), "This transport will use 8501 as its port. Secure - true");
+
+        //Transport 3
+        HashMap<String, Object> testTransport3 = ((HashMap<String, Object>) testTransports.get(2).get("testTransport"));
+        Assert.assertEquals(testTransport3.get("name"), "xyz");
+        Assert.assertEquals(testTransport3.get("port"), 9000);
+        Assert.assertEquals(testTransport3.get("secure"), true);
+        Assert.assertEquals(testTransport3.get("desc"), "This transport will use 8888 as its port");
+    }
+
     /**
      * Set environmental variables.
      */

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestTransportConfiguration2.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestTransportConfiguration2.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.config.configprovider;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Sample configuration class for testing purposes.
+ *
+ * @since 1.0.0
+ */
+@XmlRootElement
+@Configuration(namespace = "testTransports", description = "Test Transports Bean")
+class TestTransportRoot {
+
+    public List<TestTransportElement> testTransports;
+
+    TestTransportRoot() {
+        testTransports = new ArrayList<>();
+        testTransports.add(new TestTransportElement());
+    }
+
+    @XmlElement
+    public void setTestTransports(List<TestTransportElement> transportsTest) {
+        this.testTransports = transportsTest;
+    }
+
+    public List<TestTransportElement> getTestTransports() {
+        return testTransports;
+    }
+}
+
+@XmlRootElement
+@Configuration(description = "Test Transport Bean")
+class TestTransportElement {
+
+    public TestTransport testTransport = new TestTransport();
+
+    public TestTransport getTestTransport() {
+        return testTransport;
+    }
+
+    public void setTestTransport(TestTransport testTransport) {
+        this.testTransport = testTransport;
+    }
+}
+
+@XmlRootElement
+@Configuration(description = "Test Transport Bean")
+class TestTransport {
+
+    public String name = "default transport";
+    public int port = 8000;
+    public String secure = "false";
+    public String desc = "Default Transport Configurations";
+    public String password = "zzz";
+
+    @XmlAttribute
+    public void setSecure(String secure) {
+        this.secure = secure;
+    }
+
+    public String isSecure() {
+        return secure;
+    }
+
+    @XmlElement
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @XmlElement
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @XmlElement
+    public void setDesc(String desc) {
+        this.desc = desc;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    @XmlElement
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}
+

--- a/components/org.wso2.carbon.config/src/test/resources/conf/Example2.yaml
+++ b/components/org.wso2.carbon.config/src/test/resources/conf/Example2.yaml
@@ -1,0 +1,22 @@
+testTransports:
+  - testTransport:
+      name: abc
+      port: 9090
+      secure: true
+      desc: This transport will use 8000 as its port
+      password: ${sec:conn.auth.password}
+  - testTransport:
+      name: pqrs
+      port: ${env:pqr.http.port}
+      secure: ${sys:pqr.secure}
+      desc: This transport will use ${env:pqr.http.port} as its port. Secure - ${sys:pqr.secure}
+  - testTransport:
+      name: xyz
+      port: ${env:xyz.http.port,9000}
+      secure: ${sys:xyz.secure,true}
+      desc: This transport will use ${env:xyz.http.port,8888} as its port
+
+nonamespace.configuration:
+    name: transport
+    testBean:
+        id: 30


### PR DESCRIPTION
## Purpose
Add support for root level lists under namespace as follows,
```
testTransports:
  - testTransport:
      name: abc
      port: 9090
      secure: true
      desc: This transport will use 8000 as its port
      password: ${sec:conn.auth.password}
  - testTransport:
      name: pqrs
      port: ${env:pqr.http.port}
      secure: ${sys:pqr.secure}
      desc: This transport will use ${env:pqr.http.port} as its port. Secure - ${sys:pqr.secure}
  - testTransport:
      name: xyz
      port: ${env:xyz.http.port,9000}
      secure: ${sys:xyz.secure,true}
      desc: This transport will use ${env:xyz.http.port,8888} as its port
```
## Goals
Add support for root level lists under namespace which can be retrived through  `configProvider.getConfigurationObject("")` and processed as needed
As per discussions under https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8

## Approach
When dumping we if the TAG is not Map, them we dump it as a sequence and return.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - Attached to the PR
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_191
 
## Learning
N/A