### PR TITLE
Add support to get a list of config class under a namespace

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProvider.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/provider/ConfigProvider.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.config.provider;
 
 import org.wso2.carbon.config.ConfigurationException;
 
+import java.util.ArrayList;
+
 /**
  * ConfigProvider provides the configuration mapping of the class namespace.
  * This will update the configuration values with
@@ -65,4 +67,15 @@ public interface ConfigProvider {
      * @throws ConfigurationException if there is a problem while reading the configurations
      */
     <T> T getConfigurationObject(String namespace, Class<T> configClass) throws ConfigurationException;
+
+    /**
+     * Returns te configuration object list of the class under the namespace
+     *
+     * @param namespace config namespace
+     * @param configClass configuration bean class
+     * @param <T>        object type
+     * @return list of configuration object
+     * @throws ConfigurationException if there is a problem while reading the configurations
+     */
+    <T> ArrayList<T> getConfigurationObjectList(String namespace, Class<T> configClass) throws ConfigurationException;
 }

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderImplTest.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/ConfigProviderImplTest.java
@@ -789,7 +789,7 @@ public class ConfigProviderImplTest {
     }
 
     @Test(description = "This test will test functionality of namespace root level list objects")
-    public void configObjectWithConstructorTestCase() throws ConfigurationException {
+    public void configObjectWithList() throws ConfigurationException {
         ConfigFileReader fileReader = new YAMLBasedConfigFileReader(TestUtils.getResourcePath("conf",
                 "Example2.yaml").get());
         ConfigProvider configProvider = new ConfigProviderImpl(fileReader, secureVault);
@@ -820,6 +820,40 @@ public class ConfigProviderImplTest {
         Assert.assertEquals(testTransport3.get("secure"), true);
         Assert.assertEquals(testTransport3.get("desc"), "This transport will use 8888 as its port");
     }
+
+    @Test(description = "This test will test functionality of getConfigurationObjectList()")
+    public void configObjectList() throws ConfigurationException {
+        ConfigFileReader fileReader = new YAMLBasedConfigFileReader(TestUtils.getResourcePath("conf",
+                "Example2.yaml").get());
+        ConfigProvider configProvider = new ConfigProviderImpl(fileReader, secureVault);
+
+        List<TestTransportElement> testTransports =
+                            configProvider.getConfigurationObjectList("testTransports", TestTransportElement.class);
+
+        Assert.assertEquals(testTransports.size(), 3);
+
+        Assert.assertEquals(testTransports.get(0).getTestTransport().getName(), "abc");
+        Assert.assertEquals(testTransports.get(0).getTestTransport().getPort(), 9090);
+        Assert.assertEquals(testTransports.get(0).getTestTransport().isSecure(), true);
+        Assert.assertEquals(testTransports.get(0).getTestTransport().getDesc(),
+                                                        "This transport will use 8000 as its port");
+        Assert.assertEquals(testTransports.get(0).getTestTransport().getPassword(), PASSWORD);
+
+        //Transport 2
+        Assert.assertEquals(testTransports.get(1).getTestTransport().getName(), "pqrs");
+        Assert.assertEquals(testTransports.get(1).getTestTransport().getPort(), 8501);
+        Assert.assertEquals(testTransports.get(1).getTestTransport().isSecure(), true);
+        Assert.assertEquals(testTransports.get(1).getTestTransport().getDesc(),
+                                                        "This transport will use 8501 as its port. Secure - true");
+
+        //Transport 3
+        Assert.assertEquals(testTransports.get(2).getTestTransport().getName(), "xyz");
+        Assert.assertEquals(testTransports.get(2).getTestTransport().getPort(), 9000);
+        Assert.assertEquals(testTransports.get(2).getTestTransport().isSecure(), true);
+        Assert.assertEquals(testTransports.get(2).getTestTransport().getDesc(),
+                                                            "This transport will use 8888 as its port");
+    }
+
 
     /**
      * Set environmental variables.

--- a/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestTransportConfiguration2.java
+++ b/components/org.wso2.carbon.config/src/test/java/org/wso2/carbon/config/configprovider/TestTransportConfiguration2.java
@@ -70,16 +70,16 @@ class TestTransport {
 
     public String name = "default transport";
     public int port = 8000;
-    public String secure = "false";
+    public boolean secure = false;
     public String desc = "Default Transport Configurations";
     public String password = "zzz";
 
     @XmlAttribute
-    public void setSecure(String secure) {
+    public void setSecure(boolean secure) {
         this.secure = secure;
     }
 
-    public String isSecure() {
+    public boolean isSecure() {
         return secure;
     }
 


### PR DESCRIPTION
## Purpose
Add support to get a list of config class under a namespace

## Goals
To easily read the following config,
```
testTransports:
  - testTransport:
      name: abc
      port: 9090
      secure: true
      desc: This transport will use 8000 as its port
      password: ${sec:conn.auth.password}
  - testTransport:
      name: pqrs
      port: ${env:pqr.http.port}
      secure: ${sys:pqr.secure}
      desc: This transport will use ${env:pqr.http.port} as its port. Secure - ${sys:pqr.secure}
  - testTransport:
      name: xyz
      port: ${env:xyz.http.port,9000}
      secure: ${sys:xyz.secure,true}
      desc: This transport will use ${env:xyz.http.port,8888} as its port
```

## Approach
Introduced     
```
<T> ArrayList<T> getConfigurationObjectList(String namespace, Class<T> configClass) throws ConfigurationException;
```
in ConfigProvider interface to read it.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_191
 
## Learning
N/A