### PR TITLE
Add relative path support for -Dconfig parameter

### DIFF
--- a/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/ConfigFileReader.java
+++ b/components/org.wso2.carbon.config/src/main/java/org/wso2/carbon/config/reader/ConfigFileReader.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,18 @@ public abstract class ConfigFileReader {
         String customConfigContent;
         if (customConfig != null && (!customConfig.trim().isEmpty())) {
             try {
+                // Change relative paths to absolute
+                Path customConfigGivenPath = Paths.get(customConfig);
+                if (!customConfigGivenPath.isAbsolute()) {
+                    if (System.getProperty("currentDirectory") != null) {
+                        Path currentWorkingDirectory = Paths.get(
+                                System.getProperty("currentDirectory")
+                        ).toAbsolutePath();
+                        customConfig = currentWorkingDirectory.resolve(
+                                customConfigGivenPath.toString()
+                        ).normalize().toString();
+                    }
+                }
                 File customDeploymentFile = new File(customConfig);
                 if (customDeploymentFile.isFile()) {
                     log.info("Default deployment configuration updated with provided custom configuration file " +


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/distribution/issues/338

## Goals
Add relative path support for -Dconfig

## Approach
- Get the current working directory of the user using sh/bat file as a system parameter.
- Check the -Dconfig directory is relative or not.
- If it is a relative path, then change it to an absolute one and pass it.

## User stories
To enable the users has to set the current working directory and parse it as a system parameter `currentDirectory `.

## Related PRs
https://github.com/wso2/carbon-config/pull/75

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Mac OS High Sierra
Windows 10